### PR TITLE
fix: dropping presets onto the preset bucket now properly updates the

### DIFF
--- a/src/components/ColorBucket.tsx
+++ b/src/components/ColorBucket.tsx
@@ -22,6 +22,9 @@ export default function ColorBucket({theme, setThemeFile, prop}: ColorBucketProp
         }
     }));
     useEffect(()=>{
+        setFillColor(theme[prop as keyof ThemeFile]);
+    }, [theme]);
+    useEffect(()=>{
         setThemeFile({ ...theme, [prop]: fillColor });
     }, [fillColor]);
     return (


### PR DESCRIPTION
state of the color buckets in the edit component